### PR TITLE
Feat: 사용자별 캘린더 전체 조회 API 구현

### DIFF
--- a/src/main/java/fish/FishApplication.java
+++ b/src/main/java/fish/FishApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EntityScan(basePackages =  {"fish.common.fishBun.entity", "fish.common.test.entity"})
-@EnableJpaRepositories(basePackages = {"fish.common.fishBun.repository", "fish.common.test.repository"})
+@EntityScan(basePackages =  {"fish.common"})
+@EnableJpaRepositories(basePackages = {"fish.common"})
 public class FishApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(FishApplication.class, args);

--- a/src/main/java/fish/common/fishBun/controller/FishBunController.java
+++ b/src/main/java/fish/common/fishBun/controller/FishBunController.java
@@ -1,11 +1,24 @@
 package fish.common.fishBun.controller;
 
+import fish.common.fishBun.dto.response.CalendarResDTO;
 import fish.common.fishBun.service.FishBunService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class FishBunController {
     private final FishBunService fishBunService;
+
+    @GetMapping(value = "/fish-bun/calendar")
+    public ResponseEntity<List<CalendarResDTO>> getCalendarList(@RequestParam String userUUID) {
+        List<CalendarResDTO> data = fishBunService.findAllCalendarDate(userUUID);
+
+        return ResponseEntity.ok(data);
+    }
 }

--- a/src/main/java/fish/common/fishBun/controller/FishBunController.java
+++ b/src/main/java/fish/common/fishBun/controller/FishBunController.java
@@ -5,6 +5,7 @@ import fish.common.fishBun.service.FishBunService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,10 +13,11 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping(value = "/fish-bun")
 public class FishBunController {
     private final FishBunService fishBunService;
 
-    @GetMapping(value = "/fish-bun/calendar")
+    @GetMapping(value = "/calendar")
     public ResponseEntity<List<CalendarResDTO>> getCalendarList(@RequestParam String userUUID) {
         List<CalendarResDTO> data = fishBunService.findAllCalendarDate(userUUID);
 

--- a/src/main/java/fish/common/fishBun/dto/response/CalendarResDTO.java
+++ b/src/main/java/fish/common/fishBun/dto/response/CalendarResDTO.java
@@ -1,0 +1,26 @@
+package fish.common.fishBun.dto.response;
+
+import fish.common.fishBun.entity.FishBunCalendar;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CalendarResDTO {
+    private Long id;
+    private LocalDateTime date;
+
+    @Builder
+    public CalendarResDTO(Long id, LocalDateTime date) {
+        this.id = id;
+        this.date = date;
+    }
+
+    public static CalendarResDTO toResponseDTO(FishBunCalendar fishBunCalendar) {
+        return CalendarResDTO.builder()
+                .id(fishBunCalendar.getId())
+                .date(fishBunCalendar.getDate())
+                .build();
+    }
+}

--- a/src/main/java/fish/common/fishBun/entity/CalendarFlavor.java
+++ b/src/main/java/fish/common/fishBun/entity/CalendarFlavor.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "calendar_flavor")
+@Table(name = "CALENDAR_FLAVOR")
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/fish/common/fishBun/entity/CalendarFlavor.java
+++ b/src/main/java/fish/common/fishBun/entity/CalendarFlavor.java
@@ -1,22 +1,25 @@
 package fish.common.fishBun.entity;
 
-import fish.common.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "user_fish_bun_book")
+@Table(name = "calendar_flavor")
 @Getter
 @Entity
 @NoArgsConstructor
-public class UserFishBunBook {
+public class CalendarFlavor {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "calendar_id")
+    private FishBunCalendar fishBunCalendar;
 
-    private String completed_flavor;
+    @ManyToOne
+    @JoinColumn(name = "flavor_id")
+    private FishBunFlavor fishBunFlavor;
+
+
 }

--- a/src/main/java/fish/common/fishBun/entity/FishBun.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBun.java
@@ -1,0 +1,20 @@
+package fish.common.fishBun.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "fish_bun")
+@Getter
+@Entity
+@NoArgsConstructor
+public class FishBun {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String flavor;
+
+    private String image;
+}

--- a/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
@@ -26,6 +26,6 @@ public class FishBunCalendar {
     @CreationTimestamp
     private LocalDateTime date = LocalDateTime.now();
 
-    @OneToMany
-    private List<FishBun> fishBuns = new ArrayList<>();
+    @OneToMany(mappedBy = "fishBunCalendar", cascade = CascadeType.ALL)
+    private List<CalendarFlavor> flavors = new ArrayList<>();
 }

--- a/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
@@ -5,10 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
-@Table(name = "fish_bun_calendar")
+@Table(name = "FISH_BUN_CALENDAR")
 @Getter
 @Entity
 @NoArgsConstructor
@@ -24,8 +23,8 @@ public class FishBunCalendar {
     private String photo;
 
     @CreationTimestamp
-    private LocalDateTime date = LocalDateTime.now();
+    private LocalDateTime date;
 
     @OneToMany(mappedBy = "fishBunCalendar", cascade = CascadeType.ALL)
-    private List<CalendarFlavor> flavors = new ArrayList<>();
+    private List<CalendarFlavor> flavors;
 }

--- a/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBunCalendar.java
@@ -1,7 +1,12 @@
 package fish.common.fishBun.entity;
 
+import fish.common.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Table(name = "fish_bun_calendar")
 @Getter
@@ -12,6 +17,15 @@ public class FishBunCalendar {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
-    private String name;
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String photo;
+
+    @CreationTimestamp
+    private LocalDateTime date = LocalDateTime.now();
+
+    @OneToMany
+    private List<FishBun> fishBuns = new ArrayList<>();
 }

--- a/src/main/java/fish/common/fishBun/entity/FishBunFlavor.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBunFlavor.java
@@ -4,11 +4,14 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "fish_bun")
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "fish_bun_flavor")
 @Getter
 @Entity
 @NoArgsConstructor
-public class FishBun {
+public class FishBunFlavor {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -17,4 +20,7 @@ public class FishBun {
     private String flavor;
 
     private String image;
+
+    @OneToMany(mappedBy = "fishBunFlavor", cascade = CascadeType.ALL)
+    private List<CalendarFlavor> dates = new ArrayList<>();
 }

--- a/src/main/java/fish/common/fishBun/entity/FishBunFlavor.java
+++ b/src/main/java/fish/common/fishBun/entity/FishBunFlavor.java
@@ -3,11 +3,9 @@ package fish.common.fishBun.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
 import java.util.List;
 
-@Table(name = "fish_bun_flavor")
+@Table(name = "FISH_BUN_FLAVOR")
 @Getter
 @Entity
 @NoArgsConstructor
@@ -22,5 +20,5 @@ public class FishBunFlavor {
     private String image;
 
     @OneToMany(mappedBy = "fishBunFlavor", cascade = CascadeType.ALL)
-    private List<CalendarFlavor> dates = new ArrayList<>();
+    private List<CalendarFlavor> dates;
 }

--- a/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
+++ b/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
@@ -1,18 +1,22 @@
 package fish.common.fishBun.entity;
 
+import fish.common.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "fish_bun_book")
+@Table(name = "fish_bun")
 @Getter
 @Entity
 @NoArgsConstructor
-public class FishBunBook {
+public class UserFishBunBook {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
-    private String name;
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String completed_flavor;
 }

--- a/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
+++ b/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "user_fish_bun_book")
+@Table(name = "USER_FISH_BUN_BOOK")
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
+++ b/src/main/java/fish/common/fishBun/entity/UserFishBunBook.java
@@ -18,5 +18,5 @@ public class UserFishBunBook {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private String completed_flavor;
+    private String completedFlavor;
 }

--- a/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
+++ b/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
@@ -1,9 +1,9 @@
 package fish.common.fishBun.repository;
 
-import fish.common.fishBun.entity.FishBunBook;
+import fish.common.fishBun.entity.FishBun;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FishBunBookRepository extends JpaRepository<FishBunBook, String> {
+public interface FishBunBookRepository extends JpaRepository<FishBun, String> {
 }

--- a/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
+++ b/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FishBunBookRepository extends JpaRepository<FishBunFlavor, String> {
+public interface FishBunBookRepository extends JpaRepository<FishBunFlavor, Long> {
 }

--- a/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
+++ b/src/main/java/fish/common/fishBun/repository/FishBunBookRepository.java
@@ -1,9 +1,9 @@
 package fish.common.fishBun.repository;
 
-import fish.common.fishBun.entity.FishBun;
+import fish.common.fishBun.entity.FishBunFlavor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FishBunBookRepository extends JpaRepository<FishBun, String> {
+public interface FishBunBookRepository extends JpaRepository<FishBunFlavor, String> {
 }

--- a/src/main/java/fish/common/fishBun/repository/FishBunCalendarRepository.java
+++ b/src/main/java/fish/common/fishBun/repository/FishBunCalendarRepository.java
@@ -4,6 +4,9 @@ import fish.common.fishBun.entity.FishBunCalendar;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface FishBunCalendarRepository extends JpaRepository<FishBunCalendar, String> {
+public interface FishBunCalendarRepository extends JpaRepository<FishBunCalendar, Long> {
+    List<FishBunCalendar> findAllByUserId(Long id);
 }

--- a/src/main/java/fish/common/fishBun/service/FishBunService.java
+++ b/src/main/java/fish/common/fishBun/service/FishBunService.java
@@ -1,13 +1,26 @@
 package fish.common.fishBun.service;
 
+import fish.common.fishBun.dto.response.CalendarResDTO;
 import fish.common.fishBun.repository.FishBunBookRepository;
 import fish.common.fishBun.repository.FishBunCalendarRepository;
+import fish.common.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class FishBunService {
     private final FishBunCalendarRepository fishBunCalendarRepository;
     private final FishBunBookRepository fishBunBookRepository;
+    private final UserService userService;
+
+    public List<CalendarResDTO> findAllCalendarDate(String userUUID) {
+        Long userId = userService.getUserId(userUUID);
+        return fishBunCalendarRepository.findAllByUserId(userId).stream()
+                .map(CalendarResDTO::toResponseDTO)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/fish/common/user/UserController.java
+++ b/src/main/java/fish/common/user/UserController.java
@@ -1,0 +1,28 @@
+package fish.common.user;
+
+import fish.common.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    // data.sql 에서는 uuid 임의로 삽입하여 데이터 초기화
+    // uuid 필드 자동 생성하여 영속화된 entity를 DB에 잘 저장하는지 확인하는 Test user 생성 api
+    @GetMapping(value = "/test-user/save")
+    public ResponseEntity<List<User>> saveTestUser() {
+        List<User> users = List.of(
+                new User("191a0466-53d9-4c6d-9d95-71588d62658f", "fjuwrmy.png", "팥죽이", 1L),
+                new User("42a214bb-120e-4385-b2d9-0cfc6b2b8432", "duwsjqf.png", "Fania", 1L),
+                new User("ecdcda08-fb80-46cd-98ca-8db271515bbf", "xrulamo.png", "Thomasina", 2L)
+        );
+
+        return ResponseEntity.ok(userService.saveAllTestUser(users));
+    }
+}

--- a/src/main/java/fish/common/user/UserRepository.java
+++ b/src/main/java/fish/common/user/UserRepository.java
@@ -1,0 +1,12 @@
+package fish.common.user;
+
+import fish.common.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUuid(String uuid);
+}

--- a/src/main/java/fish/common/user/UserService.java
+++ b/src/main/java/fish/common/user/UserService.java
@@ -1,0 +1,24 @@
+package fish.common.user;
+
+import fish.common.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public Long getUserId(String uuid) {
+        User user = userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with UUID: " + uuid));
+
+        return user.getId();
+    }
+
+    public List<User> saveAllTestUser(List<User> testUserList) {
+        return userRepository.saveAll(testUserList);
+    }
+}

--- a/src/main/java/fish/common/user/entity/User.java
+++ b/src/main/java/fish/common/user/entity/User.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
+@Table(name = "users")
 @Getter
 @Entity
 @NoArgsConstructor
@@ -12,6 +15,9 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true, nullable = false)
+    private String uuid;
+
     // OAuth scope data
     private String providerId;
     private String picture;
@@ -19,4 +25,18 @@ public class User {
     private String nickname;
     private Long level;
 
+    @PrePersist
+    public void generateUUID() {
+        if (this.uuid == null) {
+            this.uuid = UUID.randomUUID().toString();
+        }
+    }
+
+    public User(String providerId, String picture, String nickname, Long level) {
+        this.providerId = providerId;
+        this.picture = picture;
+        this.nickname = nickname;
+        this.level = level;
+    }
 }
+

--- a/src/main/java/fish/common/user/entity/User.java
+++ b/src/main/java/fish/common/user/entity/User.java
@@ -1,0 +1,22 @@
+package fish.common.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // OAuth scope data
+    private String providerId;
+    private String picture;
+
+    private String nickname;
+    private Long level;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,16 +1,17 @@
 spring:
+  sql:
+    init:
+      mode: always
   profiles:
     active: local
   config:
     import: application-private.yml
   jpa:
     hibernate:
-      naming:
-        implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         show-sql: true
         format-sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+    defer-datasource-initialization: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,55 @@
+insert into users (provider_id, picture, nickname, level, uuid) values ('191a0466-53d9-4c6d-9d95-71588d62658f', 'fjuwrmy.png', 'Dredi', 1, 'fuangs-13941-dsdddf');
+insert into users (provider_id, picture, nickname, level, uuid) values ('456cfd2c-6198-4860-918c-cee997962d55', 'scospuz.png', 'Hildagard', 2, 'djsklg-23523-dsdddf');
+insert into users (provider_id, picture, nickname, level, uuid) values ('7412976a-eca3-42ca-89a5-d93dc0c0683a', 'gcvmqnq.png', 'Aurelia', 1, 'dgdgsd-13941-qwrgs');
+insert into users (provider_id, picture, nickname, level, uuid) values ('40ea37dc-4884-4659-bebb-b5faacd22077', 'akoquen.png', 'Nancy', 3, 'ndhdvx-426235-dsdddf');
+
+insert into fish_bun_calendar (user_id, photo, date) values (1, 'eowgt.png', '2024-07-21 15:13:09');
+insert into fish_bun_calendar (user_id, photo, date) values (2, 'fhntv.png', '2024-09-22 06:02:23');
+insert into fish_bun_calendar (user_id, photo, date) values (2, 'zrbpu.png', '2024-01-16 03:35:06');
+insert into fish_bun_calendar (user_id, photo, date) values (3, 'uiqvm.png', '2024-03-14 23:04:14');
+insert into fish_bun_calendar (user_id, photo, date) values (4, 'blumy.png', '2024-12-17 04:57:37');
+insert into fish_bun_calendar (user_id, photo, date) values (4, 'kbszj.png', '2024-02-07 17:01:19');
+insert into fish_bun_calendar (user_id, photo, date) values (4, 'lyuvj.png', '2024-08-17 07:59:25');
+insert into fish_bun_calendar (user_id, photo, date) values (4, 'vcrbs.png', '2024-11-19 19:06:17');
+insert into fish_bun_calendar (user_id, photo, date) values (2, 'lmnky.png', '2024-05-26 12:32:22');
+insert into fish_bun_calendar (user_id, photo, date) values (1, 'gikia.png', '2024-10-01 21:58:58');
+
+insert into fish_bun_flavor (id, flavor, image) values (1, '피자 붕어빵', 'wuziu.png');
+insert into fish_bun_flavor (id, flavor, image) values (2, '두부 붕어빵', 'golms.png');
+insert into fish_bun_flavor (id, flavor, image) values (3, '타코야끼 붕어빵', 'htcnq.png');
+insert into fish_bun_flavor (id, flavor, image) values (4, '팥 붕어빵', 'vmuhl.png');
+insert into fish_bun_flavor (id, flavor, image) values (5, '슈크림 붕어빵', 'nmlnv.png');
+insert into fish_bun_flavor (id, flavor, image) values (6, '고구마 붕어빵', 'xaptr.png');
+insert into fish_bun_flavor (id, flavor, image) values (7, '애플파이 붕어빵', 'fhwjd.png');
+insert into fish_bun_flavor (id, flavor, image) values (8, '귀여운 붕어빵', 'sgkrq.png');
+
+insert into user_fish_bun_book (user_id, completed_flavor) values (1, '피자 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (1, '팥 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (2, '피자 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (2, '고구마 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (3, '피자 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (3, '고구마 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (3, '뿌링클 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (3, '팥 붕어빵');
+insert into user_fish_bun_book (user_id, completed_flavor) values (4, '팥 붕어빵');
+
+
+insert into calendar_flavor (calendar_id, flavor_id) values (1, 1);
+insert into calendar_flavor (calendar_id, flavor_id) values (1, 2);
+insert into calendar_flavor (calendar_id, flavor_id) values (1, 3);
+insert into calendar_flavor (calendar_id, flavor_id) values (2, 4);
+insert into calendar_flavor (calendar_id, flavor_id) values (3, 5);
+insert into calendar_flavor (calendar_id, flavor_id) values (4, 1);
+insert into calendar_flavor (calendar_id, flavor_id) values (4, 2);
+insert into calendar_flavor (calendar_id, flavor_id) values (5, 8);
+insert into calendar_flavor (calendar_id, flavor_id) values (5, 3);
+insert into calendar_flavor (calendar_id, flavor_id) values (5, 1);
+insert into calendar_flavor (calendar_id, flavor_id) values (6, 2);
+insert into calendar_flavor (calendar_id, flavor_id) values (7, 3);
+insert into calendar_flavor (calendar_id, flavor_id) values (7, 4);
+insert into calendar_flavor (calendar_id, flavor_id) values (7, 7);
+insert into calendar_flavor (calendar_id, flavor_id) values (7, 8);
+insert into calendar_flavor (calendar_id, flavor_id) values (8, 8);
+insert into calendar_flavor (calendar_id, flavor_id) values (9, 8);
+insert into calendar_flavor (calendar_id, flavor_id) values (10, 8);
+


### PR DESCRIPTION
- user의 `uuid`를 쿼리 파라미터로 받아 사용자의 캘린더 날짜를 전체적으로 조회하는 API를 구현하였습니다.
- 프론트와의 파라미터 전달 중 보안성을 위해 `users` 테이블에 `uuid` 필드를 추가하였습니다.
- `@PrePersist` 어노테이션을 통해 Table[users]에서 `uuid` 필드를 자동 생성하고 db에 entity를 적재하도록 애플리케이션 로직을 작성하였습니다. 소셜 로그인 기능 구현 중, 정보 받아온 사용자를 db에 저장하는 코드 작성할 때 위 코드를 활용하면 좋을 것 같습니다. @InimitablePioneer 
- 테스트용 데이터 세팅 `data.sql` 스크립트에서는 `uuid` 필드 값을 임의로 넣어놨습니다. JPA save를 사용한다면 uuid가 자동 생성되어 데이터 들어가는 것 확인했습니다.

<br>

- **Response Body**

<img width="712" alt="image" src="https://github.com/user-attachments/assets/e7251d5f-8eb8-4680-a063-9c9f48ee33f7">
