### PR TITLE
Feat: 붕어빵 캘린더 상세 조회 API 구현

### DIFF
--- a/src/main/java/fish/common/fishBun/controller/FishBunController.java
+++ b/src/main/java/fish/common/fishBun/controller/FishBunController.java
@@ -26,7 +26,7 @@ public class FishBunController {
         return ResponseEntity.ok(data);
     }
 
-    @GetMapping(value = "/fish-bun/calendar/detail/{calendarId}")
+    @GetMapping(value = "/calendar/detail/{calendarId}")
     public ResponseEntity<CalendarDetailResDTO> getCalendarDetail(@PathVariable("calendarId") Long calendarId) {
         return ResponseEntity.ok(fishBunService.findCalendarDetail(calendarId));
     }

--- a/src/main/java/fish/common/fishBun/controller/FishBunController.java
+++ b/src/main/java/fish/common/fishBun/controller/FishBunController.java
@@ -1,5 +1,6 @@
 package fish.common.fishBun.controller;
 
+import fish.common.fishBun.dto.response.CalendarDetailResDTO;
 import fish.common.fishBun.dto.response.CalendarResDTO;
 import fish.common.fishBun.service.FishBunService;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -17,10 +19,15 @@ import java.util.List;
 public class FishBunController {
     private final FishBunService fishBunService;
 
-    @GetMapping(value = "/calendar")
+    @GetMapping(value = "/calendar/{userUUID}")
     public ResponseEntity<List<CalendarResDTO>> getCalendarList(@RequestParam String userUUID) {
         List<CalendarResDTO> data = fishBunService.findAllCalendarDate(userUUID);
 
         return ResponseEntity.ok(data);
+    }
+
+    @GetMapping(value = "/fish-bun/calendar/detail/{calendarId}")
+    public ResponseEntity<CalendarDetailResDTO> getCalendarDetail(@PathVariable("calendarId") Long calendarId) {
+        return ResponseEntity.ok(fishBunService.findCalendarDetail(calendarId));
     }
 }

--- a/src/main/java/fish/common/fishBun/controller/FishBunController.java
+++ b/src/main/java/fish/common/fishBun/controller/FishBunController.java
@@ -20,7 +20,7 @@ public class FishBunController {
     private final FishBunService fishBunService;
 
     @GetMapping(value = "/calendar/{userUUID}")
-    public ResponseEntity<List<CalendarResDTO>> getCalendarList(@RequestParam String userUUID) {
+    public ResponseEntity<List<CalendarResDTO>> getCalendarList(@PathVariable String userUUID) {
         List<CalendarResDTO> data = fishBunService.findAllCalendarDate(userUUID);
 
         return ResponseEntity.ok(data);

--- a/src/main/java/fish/common/fishBun/dto/response/CalendarDetailResDTO.java
+++ b/src/main/java/fish/common/fishBun/dto/response/CalendarDetailResDTO.java
@@ -1,0 +1,34 @@
+package fish.common.fishBun.dto.response;
+
+import fish.common.fishBun.entity.FishBunCalendar;
+import fish.common.fishBun.entity.FishBunFlavor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class CalendarDetailResDTO {
+    private Long id;
+    private String photo;
+    private LocalDateTime date;
+    private List<FishBunFlavor> todayFishBun;
+
+    @Builder
+    public CalendarDetailResDTO(Long id, String photo, LocalDateTime date, List<FishBunFlavor> todayFishBun) {
+        this.id = id;
+        this.photo = photo;
+        this.date = date;
+        this.todayFishBun = todayFishBun;
+    }
+
+    public static CalendarDetailResDTO toResDTO(FishBunCalendar fishBunCalendar, List<FishBunFlavor> fishBunFlavorList) {
+        return CalendarDetailResDTO.builder()
+                .id(fishBunCalendar.getId())
+                .photo(fishBunCalendar.getPhoto())
+                .date(fishBunCalendar.getDate())
+                .todayFishBun(fishBunFlavorList)
+                .build();
+    }
+}

--- a/src/main/java/fish/common/fishBun/dto/response/CalendarDetailResDTO.java
+++ b/src/main/java/fish/common/fishBun/dto/response/CalendarDetailResDTO.java
@@ -1,7 +1,6 @@
 package fish.common.fishBun.dto.response;
 
 import fish.common.fishBun.entity.FishBunCalendar;
-import fish.common.fishBun.entity.FishBunFlavor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,22 +12,22 @@ public class CalendarDetailResDTO {
     private Long id;
     private String photo;
     private LocalDateTime date;
-    private List<FishBunFlavor> todayFishBun;
+    private List<FlavorResDTO> todayFishBun;
 
     @Builder
-    public CalendarDetailResDTO(Long id, String photo, LocalDateTime date, List<FishBunFlavor> todayFishBun) {
+    public CalendarDetailResDTO(Long id, String photo, LocalDateTime date, List<FlavorResDTO> todayFishBun) {
         this.id = id;
         this.photo = photo;
         this.date = date;
         this.todayFishBun = todayFishBun;
     }
 
-    public static CalendarDetailResDTO toResDTO(FishBunCalendar fishBunCalendar, List<FishBunFlavor> fishBunFlavorList) {
+    public static CalendarDetailResDTO toResDTO(FishBunCalendar fishBunCalendar, List<FlavorResDTO> flavorResDTOList) {
         return CalendarDetailResDTO.builder()
                 .id(fishBunCalendar.getId())
                 .photo(fishBunCalendar.getPhoto())
                 .date(fishBunCalendar.getDate())
-                .todayFishBun(fishBunFlavorList)
+                .todayFishBun(flavorResDTOList)
                 .build();
     }
 }

--- a/src/main/java/fish/common/fishBun/dto/response/FlavorResDTO.java
+++ b/src/main/java/fish/common/fishBun/dto/response/FlavorResDTO.java
@@ -1,0 +1,28 @@
+package fish.common.fishBun.dto.response;
+
+import fish.common.fishBun.entity.FishBunFlavor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FlavorResDTO {
+    private Long id;
+    private String flavor;
+    private String image;
+
+    @Builder
+    public FlavorResDTO(Long id, String flavor, String image) {
+        this.id = id;
+        this.flavor = flavor;
+        this.image = image;
+
+    }
+
+    public static FlavorResDTO toResponseDTO(FishBunFlavor fishBunFlavor) {
+        return FlavorResDTO.builder()
+                .id(fishBunFlavor.getId())
+                .flavor(fishBunFlavor.getFlavor())
+                .image(fishBunFlavor.getImage())
+                .build();
+    }
+}

--- a/src/main/java/fish/common/fishBun/repository/FishBunCalendarRepository.java
+++ b/src/main/java/fish/common/fishBun/repository/FishBunCalendarRepository.java
@@ -1,7 +1,10 @@
 package fish.common.fishBun.repository;
 
 import fish.common.fishBun.entity.FishBunCalendar;
+import fish.common.fishBun.entity.FishBunFlavor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +12,9 @@ import java.util.List;
 @Repository
 public interface FishBunCalendarRepository extends JpaRepository<FishBunCalendar, Long> {
     List<FishBunCalendar> findAllByUserId(Long id);
+
+    @Query("SELECT f " +
+            "FROM FishBunFlavor f JOIN CalendarFlavor cf ON cf.fishBunFlavor.id = f.id " +
+            "WHERE cf.fishBunCalendar.id = :calendarId")
+    List<FishBunFlavor> findTodayFlavorsByCalendarId(@Param("calendarId") Long calendarId);
 }

--- a/src/main/java/fish/common/fishBun/service/FishBunService.java
+++ b/src/main/java/fish/common/fishBun/service/FishBunService.java
@@ -1,6 +1,9 @@
 package fish.common.fishBun.service;
 
+import fish.common.fishBun.dto.response.CalendarDetailResDTO;
 import fish.common.fishBun.dto.response.CalendarResDTO;
+import fish.common.fishBun.entity.FishBunCalendar;
+import fish.common.fishBun.entity.FishBunFlavor;
 import fish.common.fishBun.repository.FishBunBookRepository;
 import fish.common.fishBun.repository.FishBunCalendarRepository;
 import fish.common.user.UserService;
@@ -19,8 +22,17 @@ public class FishBunService {
 
     public List<CalendarResDTO> findAllCalendarDate(String userUUID) {
         Long userId = userService.getUserId(userUUID);
+
         return fishBunCalendarRepository.findAllByUserId(userId).stream()
                 .map(CalendarResDTO::toResponseDTO)
                 .collect(Collectors.toList());
+    }
+
+    public CalendarDetailResDTO findCalendarDetail(Long calendarId) {
+        FishBunCalendar fishBunCalendar = fishBunCalendarRepository.findById(calendarId)
+                .orElseThrow(() -> new IllegalArgumentException("Calendar data not found with id: " + calendarId));
+        List<FishBunFlavor> fishBunFlavorList = fishBunCalendarRepository.findTodayFlavorsByCalendarId(calendarId);
+
+        return CalendarDetailResDTO.toResDTO(fishBunCalendar, fishBunFlavorList);
     }
 }

--- a/src/main/java/fish/common/fishBun/service/FishBunService.java
+++ b/src/main/java/fish/common/fishBun/service/FishBunService.java
@@ -31,12 +31,12 @@ public class FishBunService {
     public CalendarDetailResDTO findCalendarDetail(Long calendarId) {
         FishBunCalendar fishBunCalendar = fishBunCalendarRepository.findById(calendarId)
                 .orElseThrow(() -> new IllegalArgumentException("Calendar data not found with id: " + calendarId));
-        List<FlavorResDTO> flavorResDTOList =
+        List<FlavorResDTO> FlavorResDTOListByDate =
                 fishBunCalendarRepository.findTodayFlavorsByCalendarId(calendarId)
                         .stream()
                         .map(FlavorResDTO::toResponseDTO)
                         .toList();
 
-        return CalendarDetailResDTO.toResDTO(fishBunCalendar, flavorResDTOList);
+        return CalendarDetailResDTO.toResDTO(fishBunCalendar, FlavorResDTOListByDate);
     }
 }

--- a/src/main/java/fish/common/fishBun/service/FishBunService.java
+++ b/src/main/java/fish/common/fishBun/service/FishBunService.java
@@ -2,8 +2,8 @@ package fish.common.fishBun.service;
 
 import fish.common.fishBun.dto.response.CalendarDetailResDTO;
 import fish.common.fishBun.dto.response.CalendarResDTO;
+import fish.common.fishBun.dto.response.FlavorResDTO;
 import fish.common.fishBun.entity.FishBunCalendar;
-import fish.common.fishBun.entity.FishBunFlavor;
 import fish.common.fishBun.repository.FishBunBookRepository;
 import fish.common.fishBun.repository.FishBunCalendarRepository;
 import fish.common.user.UserService;
@@ -31,8 +31,12 @@ public class FishBunService {
     public CalendarDetailResDTO findCalendarDetail(Long calendarId) {
         FishBunCalendar fishBunCalendar = fishBunCalendarRepository.findById(calendarId)
                 .orElseThrow(() -> new IllegalArgumentException("Calendar data not found with id: " + calendarId));
-        List<FishBunFlavor> fishBunFlavorList = fishBunCalendarRepository.findTodayFlavorsByCalendarId(calendarId);
+        List<FlavorResDTO> flavorResDTOList =
+                fishBunCalendarRepository.findTodayFlavorsByCalendarId(calendarId)
+                        .stream()
+                        .map(FlavorResDTO::toResponseDTO)
+                        .toList();
 
-        return CalendarDetailResDTO.toResDTO(fishBunCalendar, fishBunFlavorList);
+        return CalendarDetailResDTO.toResDTO(fishBunCalendar, flavorResDTOList);
     }
 }


### PR DESCRIPTION
- 붕어빵 캘린더 상세 데이터를 조회하는 API를 구현하였습니다.
- 캘린더 id는 고유한 값이므로 userUUID도 파라미터로 굳이 받아올 필요가 없어 request Parameter로 캘린더 id만 받아오는 것으로 수정하였습니다.
- Request Parameter 받아오는 방식을 쿼리 스트링 -> `@PathVariable`로 바꿨습니다.
- 해당 날짜 캘린더에 속하는 붕어빵 맛의 관련 데이터만 뽑아오기 위해 `FlavorResDTO`를 추가하였습니다.

<br>

<img width="704" alt="image" src="https://github.com/user-attachments/assets/a89bd4a5-84a7-446b-8d9c-21a7427d3f14">
