### PR TITLE
Feat: 메인 주간 붕어빵 요일 조회하기

### DIFF
--- a/src/main/java/fish/common/book/repository/UserBookRepository.java
+++ b/src/main/java/fish/common/book/repository/UserBookRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface UserBookRepository extends JpaRepository<UserBook, Long> {
-    List<UserBook> findAllByUserId(Long id);
+    List<UserBook> findAllByUserId(Long userId);
 }

--- a/src/main/java/fish/common/book/service/BookService.java
+++ b/src/main/java/fish/common/book/service/BookService.java
@@ -12,8 +12,8 @@ import java.util.List;
 public class BookService {
     private final UserBookRepository userBookRepository;
 
-    public List<UserBookResponse> findAllUserFishBunBook(Long id) {
-        return userBookRepository.findAllByUserId(id).stream()
+    public List<UserBookResponse> findAllUserFishBunBook(Long userId) {
+        return userBookRepository.findAllByUserId(userId).stream()
                 .map(UserBookResponse::toResponseDTO)
                 .toList();
     }

--- a/src/main/java/fish/common/main/entity/controller/MainController.java
+++ b/src/main/java/fish/common/main/entity/controller/MainController.java
@@ -1,0 +1,25 @@
+package fish.common.main.entity.controller;
+
+import fish.common.main.entity.response.FishBunDayCountResponse;
+import fish.common.main.entity.service.MainService;
+import fish.core.oauth.dto.AuthUserInfo;
+import fish.core.util.ResponseUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/fish-bun")
+public class MainController {
+    private final MainService mainService;
+
+    @GetMapping(value = "/main")
+    public ResponseUtil<FishBunDayCountResponse> countFishBunDaysInWeek(@AuthenticationPrincipal AuthUserInfo authUserInfo) {
+        FishBunDayCountResponse data = mainService.countFishBunDaysInWeek(authUserInfo.getUser().getId());
+
+        return ResponseUtil.success(data);
+    }
+}

--- a/src/main/java/fish/common/main/entity/repository/MainRepository.java
+++ b/src/main/java/fish/common/main/entity/repository/MainRepository.java
@@ -1,0 +1,18 @@
+package fish.common.main.entity.repository;
+
+import fish.common.main.entity.FishBunDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Repository
+public interface MainRepository extends JpaRepository<FishBunDetail, Long> {
+    @Query(value = "SELECT COUNT(*) AS weeklyCount, GROUP_CONCAT(DAYNAME(`date`)) AS days " +
+                    "FROM FISH_BUN_DETAIL " +
+                    "WHERE userId = ?1 AND `date` BETWEEN " +
+                    "DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) DAY) AND " +
+                    "DATE_ADD(DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) DAY), INTERVAL 7 DAY)", nativeQuery = true)
+    Map<String, Object> countCurrentWeekData(Long userId);
+}

--- a/src/main/java/fish/common/main/entity/response/FishBunDayCountResponse.java
+++ b/src/main/java/fish/common/main/entity/response/FishBunDayCountResponse.java
@@ -1,0 +1,12 @@
+package fish.common.main.entity.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FishBunDayCountResponse {
+    private List<String> daysInWeek;
+    private int weeklyCount;
+}

--- a/src/main/java/fish/common/main/entity/service/MainService.java
+++ b/src/main/java/fish/common/main/entity/service/MainService.java
@@ -1,0 +1,28 @@
+package fish.common.main.entity.service;
+
+import fish.common.main.entity.repository.MainRepository;
+import fish.common.main.entity.response.FishBunDayCountResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MainService {
+    private final MainRepository mainRepository;
+
+    public FishBunDayCountResponse countFishBunDaysInWeek(Long userId) {
+        Map<String, Object> result = mainRepository.countCurrentWeekData(userId);
+
+        if (result != null) {
+            int count = Integer.parseInt(result.get("weeklyCount").toString());
+            List<String> days = Arrays.asList(result.get("days").toString().split(","));
+
+            return new FishBunDayCountResponse(days, count);
+        }
+        return new FishBunDayCountResponse(Collections.emptyList(), 0);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,6 +9,12 @@ INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (3, '팥 붕어빵', 
 INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (3, '누텔라 붕어빵, 팥 붕어빵', '2024-10-01 15:28:44');
 INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '애플파이 붕어빵, 팥 붕어빵', '2024-11-22 11:12:58');
 INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '슈크림 붕어빵', '2024-11-23 21:00:58');
+INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '슈크림 붕어빵', '2024-12-10 21:00:58');
+INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '슈크림 붕어빵', '2024-12-11 21:00:58');
+INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '슈크림 붕어빵', '2024-12-15 21:00:58');
+INSERT INTO FISH_BUN_DETAIL (userId, flavors, date) values (5, '슈크림 붕어빵', '2024-12-17 21:00:58');
+
+
 
 INSERT INTO FISH_BUN_FLAVOR (flavor, image) values ('피자 붕어빵', 'wuziu.png');
 INSERT INTO FISH_BUN_FLAVOR (flavor, image) values ('두부 붕어빵', 'golms.png');


### PR DESCRIPTION
- `메인 리스트 조회하기 `-> `메인 주간 붕어빵 요일 조회하기`로 API명을 기능에 중점을 둔 방향으로 수정하였습니다.
- 현재 날짜를 기준으로 월~일 (1주) 사이의 `FISH_BUN_DETAIL` 테이블 **데이터의 개수**와 **붕어빵 기록한 날짜 요일들**을 리스트화하여 응답값으로 반환하였습니다.

```json
{
  "data": {
    "daysInWeek": [
      "Tuesday",
      "Wednesday",
      "Sunday"
    ],
    "weeklyCount": 3
  },
  "result": "success",
  "statusCode": "200"
}
```