### PR TITLE
Feat: 붕어빵 맛 제보하기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web-services'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.security:spring-security-oauth2-client'

--- a/src/main/java/fish/common/book/controller/BookController.java
+++ b/src/main/java/fish/common/book/controller/BookController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/fish-bun/book")
+@RequestMapping(value = "/api/fish-bun/book")
 public class BookController {
     private final BookService bookService;
 

--- a/src/main/java/fish/common/calendar/controller/CalendarController.java
+++ b/src/main/java/fish/common/calendar/controller/CalendarController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/fish-bun/calendar")
+@RequestMapping(value = "/api/fish-bun/calendar")
 public class CalendarController {
     private final CalendarService calendarService;
 

--- a/src/main/java/fish/common/detail/controller/DetailController.java
+++ b/src/main/java/fish/common/detail/controller/DetailController.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/fish-bun/detail")
+@RequestMapping(value = "/api/fish-bun/detail")
 public class DetailController {
     private final DetailService mainService;
 

--- a/src/main/java/fish/common/flavor/controller/FlavorController.java
+++ b/src/main/java/fish/common/flavor/controller/FlavorController.java
@@ -1,14 +1,16 @@
 package fish.common.flavor.controller;
 
+import fish.common.flavor.request.FlavorReportRequest;
 import fish.common.flavor.response.FlavorResponse;
 import fish.common.flavor.service.FlavorService;
+import fish.core.oauth.dto.AuthUserInfo;
 import fish.core.util.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -21,5 +23,15 @@ public class FlavorController {
     public ResponseEntity<ResponseUtil<List<FlavorResponse>>> getFlavorList() {
         List<FlavorResponse> data = flavorService.findAllFlavors();
         return ResponseEntity.ok(ResponseUtil.success(data));
+    }
+
+    @PostMapping(value = "/report")
+    public ResponseEntity report(@RequestBody FlavorReportRequest request, @AuthenticationPrincipal AuthUserInfo authUserInfo) {
+        List<String> flavors = Arrays.stream(request.getFlavors().split(",\\s*")).map(String::trim).toList();
+        for (String flavor: flavors) {
+            flavorService.saveReportData(flavor, authUserInfo.getUser().getId());
+        }
+
+        return ResponseEntity.ok(ResponseUtil.success());
     }
 }

--- a/src/main/java/fish/common/flavor/controller/FlavorController.java
+++ b/src/main/java/fish/common/flavor/controller/FlavorController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/fish-bun")
+@RequestMapping(value = "/api/fish-bun")
 public class FlavorController {
     private final FlavorService flavorService;
 

--- a/src/main/java/fish/common/flavor/entity/FishBunFlavorReport.java
+++ b/src/main/java/fish/common/flavor/entity/FishBunFlavorReport.java
@@ -1,0 +1,34 @@
+package fish.common.flavor.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Table(name = "FISH_BUN_FLAVOR_REPORT")
+@Entity
+@Getter
+public class FishBunFlavorReport {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String flavor;
+    private Long userId;
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Builder
+    public FishBunFlavorReport(String flavor, Long userId, Status status) {
+        this.flavor = flavor;
+        this.userId = userId;
+        this.status = status;
+    }
+
+    public static FishBunFlavorReport toEntity(String flavor, Long userId) {
+        return FishBunFlavorReport.builder()
+                .flavor(flavor)
+                .userId(userId)
+                .status(Status.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/fish/common/flavor/entity/Status.java
+++ b/src/main/java/fish/common/flavor/entity/Status.java
@@ -1,0 +1,5 @@
+package fish.common.flavor.entity;
+
+public enum Status {
+    APPROVED, PENDING, DENIED
+}

--- a/src/main/java/fish/common/flavor/repository/FlavorReportRepository.java
+++ b/src/main/java/fish/common/flavor/repository/FlavorReportRepository.java
@@ -1,0 +1,9 @@
+package fish.common.flavor.repository;
+
+import fish.common.flavor.entity.FishBunFlavorReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FlavorReportRepository extends JpaRepository<FishBunFlavorReport, Long> {
+}

--- a/src/main/java/fish/common/flavor/request/FlavorReportRequest.java
+++ b/src/main/java/fish/common/flavor/request/FlavorReportRequest.java
@@ -1,0 +1,10 @@
+package fish.common.flavor.request;
+
+import lombok.Getter;
+import jakarta.validation.constraints.NotNull;
+
+@Getter
+public class FlavorReportRequest {
+    @NotNull
+    private String flavors;
+}

--- a/src/main/java/fish/common/flavor/service/FlavorService.java
+++ b/src/main/java/fish/common/flavor/service/FlavorService.java
@@ -1,5 +1,7 @@
 package fish.common.flavor.service;
 
+import fish.common.flavor.entity.FishBunFlavorReport;
+import fish.common.flavor.repository.FlavorReportRepository;
 import fish.common.flavor.repository.FlavorRepository;
 import fish.common.flavor.response.FlavorResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +13,17 @@ import java.util.List;
 @Service
 public class FlavorService {
     private final FlavorRepository fishBunFlavorRepository;
+    private final FlavorReportRepository flavorReportRepository;
 
     public List<FlavorResponse> findAllFlavors() {
         return fishBunFlavorRepository.findAll()
                 .stream()
                 .map(FlavorResponse::toResponseDTO)
                 .toList();
+    }
+
+    public void saveReportData(String flavor, Long userId) {
+        FishBunFlavorReport flavorReport = FishBunFlavorReport.toEntity(flavor, userId);
+        flavorReportRepository.save(flavorReport);
     }
 }

--- a/src/main/java/fish/common/main/entity/controller/MainController.java
+++ b/src/main/java/fish/common/main/entity/controller/MainController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/fish-bun")
+@RequestMapping(value = "/api/fish-bun")
 public class MainController {
     private final MainService mainService;
 

--- a/src/main/java/fish/core/config/SecurityConfig.java
+++ b/src/main/java/fish/core/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                                     , "/images/**"
                                     , "/js/**"
                             ).permitAll() // 인증 없이 접근 가능
-                    .requestMatchers("/fish-bun/**").authenticated()
+                    .requestMatchers("/api/fish-bun/**").authenticated()
             ;
         });
         http.oauth2Login(form -> {

--- a/src/main/java/fish/core/util/ResponseUtil.java
+++ b/src/main/java/fish/core/util/ResponseUtil.java
@@ -1,6 +1,6 @@
 package fish.core.util;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,7 +10,7 @@ public class ResponseUtil<T> {
     private static final String MESSAGE_SUCCESS = "success";
     private static final String CODE_SUCCESS = "200";
 
-    @JsonIgnore
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
     private String result;
     private String statusCode;


### PR DESCRIPTION
- 찾아보니 state는 어떤 행위의 "과정"에 중점을 두고 있고, status는 "결과"에 중점을 두고 있다고 합니다. 데이터 승인 시스템 같은 결과 중심적 데이터는 `status`를 많이 쓴다고 하여, status로 필드명을 변경하였습니다!
  -  `APPROVED`, `PENDING`, `DENIED` 데이터 현재 결과 상태에 3개의 상태를 갖는 enum 클래스를 만들었습니다.

<br>

<img width="434" alt="image" src="https://github.com/user-attachments/assets/17075b4b-b4d4-4276-a464-70d62a63a469" />
