### PR TITLE
Feat. 구글 및 네이버 로그인 구현

### DIFF
--- a/document/DDL/2024/[2024.12.15-01] initDDL.sql
+++ b/document/DDL/2024/[2024.12.15-01] initDDL.sql
@@ -40,7 +40,7 @@ CREATE TABLE `FISH_BUN_FLAVOR_REPORT` (
 CREATE TABLE `USER` (
                         `id` bigint NOT NULL AUTO_INCREMENT,
                         `level` bigint DEFAULT NULL,
-                        `providerId` bigint DEFAULT NULL,
+                        `providerId` varchar(50) DEFAULT NULL,
                         `nickname` varchar(15) DEFAULT NULL,
                         `providerProfile` varchar(100) DEFAULT NULL,
                         `providerType` varchar(20) DEFAULT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE `USER_FISH_BUN_BOOK` (
 CREATE TABLE `USER_HISTORY` (
                                 `id` bigint NOT NULL AUTO_INCREMENT,
                                 `date` datetime(6) DEFAULT NULL,
-                                `providerId` bigint DEFAULT NULL,
+                                `providerId` varchar(50) DEFAULT NULL,
                                 `ip` varchar(40) DEFAULT NULL,
                                 PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/src/main/java/fish/common/history/user/entity/UserHistory.java
+++ b/src/main/java/fish/common/history/user/entity/UserHistory.java
@@ -15,12 +15,12 @@ public class UserHistory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long providerId;
+    private String providerId;
     private String ip;
     @CreationTimestamp
     private LocalDateTime date;
 
-    public UserHistory(Long providerId, String ip) {
+    public UserHistory(String providerId, String ip) {
         this.providerId = providerId;
         this.ip = ip;
     }

--- a/src/main/java/fish/common/user/entity/User.java
+++ b/src/main/java/fish/common/user/entity/User.java
@@ -20,7 +20,7 @@ public class User {
     private String uuid;
 
     // OAuth scope data
-    private Long providerId;
+    private String providerId;
 
     private String providerType; //타입 구분(kakao, google, naver)
     private String providerProfile;

--- a/src/main/java/fish/common/user/repository/UserRepository.java
+++ b/src/main/java/fish/common/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByProviderId(Long providerId);
+    Optional<User> findByProviderId(String providerId);
     Optional<User> findById(Long id);
 
 }

--- a/src/main/java/fish/common/user/service/UserService.java
+++ b/src/main/java/fish/common/user/service/UserService.java
@@ -17,7 +17,7 @@ public class UserService {
                 );
     }
 
-    public User getUserById(String providerId) {
+    public User getUserByProviderId(String providerId) {
         return userRepository.findByProviderId(providerId)
                 .orElseGet(() ->
                         null

--- a/src/main/java/fish/common/user/service/UserService.java
+++ b/src/main/java/fish/common/user/service/UserService.java
@@ -17,7 +17,7 @@ public class UserService {
                 );
     }
 
-    public User getUserById(long providerId) {
+    public User getUserById(String providerId) {
         return userRepository.findByProviderId(providerId)
                 .orElseGet(() ->
                         null

--- a/src/main/java/fish/global/config/LoginAuthHandler.java
+++ b/src/main/java/fish/global/config/LoginAuthHandler.java
@@ -39,7 +39,7 @@ public class LoginAuthHandler extends SimpleUrlAuthenticationSuccessHandler
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException {
-        long providerId = Long.parseLong(authentication.getName());
+        String providerId = authentication.getName();
         //로그인 이력 히스토리 쌓음
         userHistoryService.saveHistory(
                 new UserHistory(providerId , IpAddressUtil.getClientIp(request)

--- a/src/main/java/fish/global/config/LoginAuthHandler.java
+++ b/src/main/java/fish/global/config/LoginAuthHandler.java
@@ -46,7 +46,7 @@ public class LoginAuthHandler extends SimpleUrlAuthenticationSuccessHandler
                 )
         );
         //유저 값 가져와서
-        User user = userService.getUserById(providerId);
+        User user = userService.getUserByProviderId(providerId);
         response.addCookie(setCookie(authentication));
         //유저가 닉네임이 등록되어있을 시에 Main으로 리턴, 존재하지 않을 시 Nickname 등록 URL로 리턴
         String path = user.getNickname() != null ? MAIN_URL : NICKNAME_URL;

--- a/src/main/java/fish/global/config/OAuth2TokenFilter.java
+++ b/src/main/java/fish/global/config/OAuth2TokenFilter.java
@@ -86,7 +86,7 @@ public class OAuth2TokenFilter extends OncePerRequestFilter {
 
             ObjectMapper objectMapper = new ObjectMapper();
             Map<String, Object> responseData = objectMapper.readValue(entity.getBody(), Map.class);
-            return userService.getUserById((Long)responseData.get("id"));
+            return userService.getUserById(responseData.get("id").toString());
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/fish/global/config/OAuth2TokenFilter.java
+++ b/src/main/java/fish/global/config/OAuth2TokenFilter.java
@@ -86,7 +86,7 @@ public class OAuth2TokenFilter extends OncePerRequestFilter {
 
             ObjectMapper objectMapper = new ObjectMapper();
             Map<String, Object> responseData = objectMapper.readValue(entity.getBody(), Map.class);
-            return userService.getUserById(responseData.get("id").toString());
+            return userService.getUserByProviderId(responseData.get("id").toString());
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/fish/global/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/fish/global/oauth/dto/GoogleUserInfo.java
@@ -2,29 +2,30 @@
 package fish.global.oauth.dto;
 
 import lombok.Getter;
+
 import java.util.Map;
 
 @Getter
-public class KakaoUserInfo implements OAuth2UserInfo {
+public class GoogleUserInfo implements OAuth2UserInfo {
 
     private Map<String, Object> attributes; // getAttributes()
-    public KakaoUserInfo(Map<String, Object> attributes) {
+    public GoogleUserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
     }
 
     @Override
     public String getProviderId() {
-        return (String) attributes.get("id");
+        return (String)attributes.get("sub");
     }
 
     @Override
     public String getProviderType() {
-        return "kakao";
+        return "google";
     }
 
     @Override
     public String getProviderProfile() {
-        return ((Map)attributes.get("properties")).get("profile_image").toString();
+        return (String) attributes.get("picture");
     }
 
 }

--- a/src/main/java/fish/global/oauth/dto/NaverUserInfo.java
+++ b/src/main/java/fish/global/oauth/dto/NaverUserInfo.java
@@ -2,29 +2,30 @@
 package fish.global.oauth.dto;
 
 import lombok.Getter;
+
 import java.util.Map;
 
 @Getter
-public class KakaoUserInfo implements OAuth2UserInfo {
+public class NaverUserInfo implements OAuth2UserInfo {
 
     private Map<String, Object> attributes; // getAttributes()
-    public KakaoUserInfo(Map<String, Object> attributes) {
-        this.attributes = attributes;
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = (Map<String, Object>) attributes.get("response");
     }
 
     @Override
     public String getProviderId() {
-        return (String) attributes.get("id");
+        return (String)attributes.get("id");
     }
 
     @Override
     public String getProviderType() {
-        return "kakao";
+        return "naver";
     }
 
     @Override
     public String getProviderProfile() {
-        return ((Map)attributes.get("properties")).get("profile_image").toString();
+        return (String) attributes.get("profile_image");
     }
 
 }

--- a/src/main/java/fish/global/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/fish/global/oauth/dto/OAuth2UserInfo.java
@@ -1,11 +1,11 @@
 package fish.global.oauth.dto;
 
 /**
- * Oauth2UserInfo 구현체(나중에 카카오톡 뿐만 아니라, 구글, 네이버 로그인 기능 구현시에 구현체로써 활용)
+ * Oauth2UserInfo 구현체
  * */
 public interface OAuth2UserInfo {
 
-    Long getProviderId();
+    String getProviderId();
     String getProviderType();
     String getProviderProfile();
 }

--- a/src/main/java/fish/global/oauth/service/OAuthUserService.java
+++ b/src/main/java/fish/global/oauth/service/OAuthUserService.java
@@ -19,7 +19,6 @@ public class OAuthUserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2UserInfo userInfo;
         String attributeKey;
-        //현재 카카오톡만 있기에 카카오톡 처리만 들어감. (추후에 네이버, 구글 로그인도 들어갈 예정)
         switch (registrationId) {
             case "kakao":
                 userInfo = new KakaoUserInfo(oAuth2User.getAttributes());

--- a/src/main/java/fish/global/oauth/service/OAuthUserService.java
+++ b/src/main/java/fish/global/oauth/service/OAuthUserService.java
@@ -1,8 +1,6 @@
 package fish.global.oauth.service;
 
-import fish.global.oauth.dto.AuthUserInfo;
-import fish.global.oauth.dto.KakaoUserInfo;
-import fish.global.oauth.dto.OAuth2UserInfo;
+import fish.global.oauth.dto.*;
 import fish.common.user.entity.User;
 import fish.common.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +18,21 @@ public class OAuthUserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2UserInfo userInfo;
+        String attributeKey;
         //현재 카카오톡만 있기에 카카오톡 처리만 들어감. (추후에 네이버, 구글 로그인도 들어갈 예정)
         switch (registrationId) {
-            case "kakao": userInfo = new KakaoUserInfo(oAuth2User.getAttributes()); break;
+            case "kakao":
+                userInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+                attributeKey = "id";
+                break;
+            case "google":
+                userInfo = new GoogleUserInfo(oAuth2User.getAttributes());
+                attributeKey = "sub";
+                break;
+            case "naver":
+                userInfo = new NaverUserInfo(oAuth2User.getAttributes());
+                attributeKey = "id";
+                break;
             default: return null;
         }
 
@@ -30,7 +40,7 @@ public class OAuthUserService extends DefaultOAuth2UserService {
         return new AuthUserInfo(
                 oAuth2User.getAuthorities(),
                 oAuth2User.getAttributes(),
-                "id",
+                attributeKey,
                 user
         );
     }


### PR DESCRIPTION
- Naver/Google UserInfo 구현체 생성
- Naver/Google이 제공하는 id는 Long의 사이즈를 넘거나, 문자열 형태로 되어있어 String으로 타입 변환
- InitDDL에 providerId BigInt -> Varchar(50)
- application-private.yml 및 application-prod.yml에 구글/네이버 관련 Oauth 정보 추가(notion에 공유)