### PR TITLE
Feat: JSON 데이터 처리를 @Converter 방식으로 변경

### DIFF
--- a/src/main/java/fish/common/calendar/repository/CalendarRepository.java
+++ b/src/main/java/fish/common/calendar/repository/CalendarRepository.java
@@ -16,10 +16,10 @@ public interface CalendarRepository extends JpaRepository<DetailEntity, Long> {
             "WHERE YEAR(`regDate`) = ?1 AND MONTH(`regDate`) = ?2 AND F.userId = ?3", nativeQuery = true)
     List<Map<String, Object>> findAllByUserId(int year, int month, Long userId);
 
-    @Query(value = "SELECT F.flavors " +
-                    "FROM FISH_BUN_DETAIL F " +
-                    "WHERE YEAR(`regDate`) = ?1 AND MONTH(`regDate`) = ?2 AND F.userId = ?3", nativeQuery = true)
-    List<String> getMonthlyCountByMonth(int year, int month, Long userId);
+    @Query("SELECT f " +
+            "FROM DetailEntity f " +
+            "WHERE YEAR(f.regDate) = ?1 AND MONTH(f.regDate) = ?2 AND f.userId = ?3")
+    List<DetailEntity> getMonthlyCountByMonth(int year, int month, Long userId);
 
     Optional<DetailEntity> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/fish/common/calendar/response/CalendarDetailResponse.java
+++ b/src/main/java/fish/common/calendar/response/CalendarDetailResponse.java
@@ -1,20 +1,22 @@
 package fish.common.calendar.response;
 
+import fish.common.detail.dto.DetailFlavor;
 import fish.common.detail.entity.DetailEntity;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class CalendarDetailResponse {
     private Long id;
     private String fileUrl;
     private LocalDateTime regDate;
-    private String flavors;
+    private List<DetailFlavor> flavors;
 
     @Builder
-    public CalendarDetailResponse(Long id, String fileUrl, LocalDateTime date, String flavors) {
+    public CalendarDetailResponse(Long id, String fileUrl, LocalDateTime date, List<DetailFlavor> flavors) {
         this.id = id;
         this.fileUrl = fileUrl;
         this.regDate = date;

--- a/src/main/java/fish/common/calendar/service/CalendarService.java
+++ b/src/main/java/fish/common/calendar/service/CalendarService.java
@@ -43,18 +43,9 @@ public class CalendarService {
     }
 
     public int getFishBunCountByMonth(int year, int month, Long userId) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        List<DetailEntity> detailEntity = calendarRepository.getMonthlyCountByMonth(year, month, userId);
 
-        List<String> flavorJson = calendarRepository.getMonthlyCountByMonth(year, month, userId);
-
-        int monthlyTotal = 0;
-        for (String flavors : flavorJson) {
-            DetailFlavor[] detailFlavors = objectMapper.readValue(flavors, DetailFlavor[].class);
-            for (DetailFlavor detailFlavor : detailFlavors) {
-                monthlyTotal += detailFlavor.getCount();
-            }
-        }
-        return monthlyTotal;
+        return detailEntity.stream().flatMap(entity -> entity.getFlavors().stream()).mapToInt(DetailFlavor::getCount).sum();
     }
 
 }

--- a/src/main/java/fish/common/detail/controller/DetailController.java
+++ b/src/main/java/fish/common/detail/controller/DetailController.java
@@ -24,16 +24,14 @@ import java.util.List;
 public class DetailController {
     private final DetailService detailService;
     private final BookService bookService;
-    ObjectMapper objectMapper = new ObjectMapper();
 
     @PostMapping(value = "/save", consumes = {"multipart/form-data"})
     public ResponseEntity<ResponseUtil<Long>> save(@ModelAttribute DetailRequest request,
-                               @AuthenticationPrincipal User user) throws IOException {
+                                                   @AuthenticationPrincipal User user) throws IOException {
         DetailEntity entity = request.toEntity(request, user.getId());
         Long id = detailService.save(entity, request.getPicture());
         // Update the user book for a new flavor
-        DetailFlavor[] detailFlavors = objectMapper.readValue(entity.getFlavors(), DetailFlavor[].class);
-        List<Long> flavorIdList = Arrays.stream(detailFlavors).map(DetailFlavor::getFlavorId).toList();
+        List<Long> flavorIdList = entity.getFlavors().stream().map(DetailFlavor::getFlavorId).toList();
         bookService.saveUserCompletedFlavor(flavorIdList, user.getId());
 
         return ResponseEntity.ok(ResponseUtil.success(id));

--- a/src/main/java/fish/common/detail/converter/DetailFlavorConverter.java
+++ b/src/main/java/fish/common/detail/converter/DetailFlavorConverter.java
@@ -1,0 +1,40 @@
+package fish.common.detail.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fish.common.detail.dto.DetailFlavor;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class DetailFlavorConverter implements AttributeConverter<List<DetailFlavor>, String> {
+    private static final Logger log = LoggerFactory.getLogger(DetailFlavorConverter.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<DetailFlavor> detailFlavor) {
+        // Transfer DetailFlavor to Json
+        try {
+            return objectMapper.writeValueAsString(detailFlavor);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize List<DetailFlavor> to Json. Input: {}", detailFlavor, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<DetailFlavor> convertToEntityAttribute(String json) {
+        // Transfer Json To DetailFlavor
+        try {
+            return Arrays.asList(objectMapper.readValue(json, DetailFlavor[].class));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize JSON to DetailFlavor. Input: {}", json, e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/fish/common/detail/dto/DetailRequest.java
+++ b/src/main/java/fish/common/detail/dto/DetailRequest.java
@@ -1,9 +1,14 @@
 package fish.common.detail.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fish.common.detail.entity.DetailEntity;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Data
 @RequiredArgsConstructor
@@ -11,9 +16,12 @@ public class DetailRequest {
     private String flavors;
     private MultipartFile picture;
 
-    public DetailEntity toEntity(DetailRequest request, Long userId) {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public DetailEntity toEntity(DetailRequest request, Long userId) throws JsonProcessingException {
+        List<DetailFlavor> detailFlavors = Arrays.asList(objectMapper.readValue(request.flavors, DetailFlavor[].class));
         return DetailEntity.builder()
-                .flavors(request.flavors)
+                .flavors(detailFlavors)
                 .userId(userId)
                 .build();
     }

--- a/src/main/java/fish/common/detail/entity/DetailEntity.java
+++ b/src/main/java/fish/common/detail/entity/DetailEntity.java
@@ -1,10 +1,13 @@
 package fish.common.detail.entity;
 
+import fish.common.detail.converter.DetailFlavorConverter;
+import fish.common.detail.dto.DetailFlavor;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "FISH_BUN_DETAIL")
@@ -17,7 +20,8 @@ public class DetailEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long userId;
-    private String flavors;
+    @Convert(converter = DetailFlavorConverter.class)
+    private List<DetailFlavor> flavors;
     @CreationTimestamp
     private LocalDateTime regDate;
     private Long fileId;

--- a/src/main/java/fish/common/detail/service/DetailService.java
+++ b/src/main/java/fish/common/detail/service/DetailService.java
@@ -1,8 +1,6 @@
 package fish.common.detail.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import fish.common.detail.dto.DetailFlavor;
 import fish.common.detail.response.DetailResponse;
 import fish.common.file.entity.FileEntity;
 import fish.common.file.service.FileService;
@@ -17,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,7 +25,6 @@ public class DetailService {
     private final DetailRepository detailRepository;
     private final FlavorRepository flavorRepository;
     private final FileService fileService;
-    ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
     public Long save(DetailEntity entity, MultipartFile picture) throws IOException {
@@ -41,9 +37,8 @@ public class DetailService {
     public List<DetailResponse> findRegistrationData(Long detailId, Long userId) throws JsonProcessingException {
         DetailEntity detailEntity = detailRepository.findByIdAndUserId(detailId, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Detail Entity not found with ID: " + detailId));
-        DetailFlavor[] detailFlavors = objectMapper.readValue(detailEntity.getFlavors(), DetailFlavor[].class);
 
-        return Arrays.stream(detailFlavors)
+        return detailEntity.getFlavors().stream()
                 .map(detailFlavor -> {
                     Long flavorId = detailFlavor.getFlavorId();
                     String iconCode = flavorRepository.findIconCodeById(flavorId).getIconCode();


### PR DESCRIPTION
JSON 데이터 처리 방식을 `@Converter`로 개선하였습니다.

- 기존 ObjectMapper를 사용한 수동 변환 작업을 자동 변환으로 바꾸어, 서비스 및 컨트롤러 레이어에서 중복되는 JSON 처리 코드를 줄였습니다. 다만, 컨버터는 JPA에서 DB <-> Entity 변환에 사용되고, Request -> DTO 요청 바인딩에서는 동작하지 않으므로 그 부분에서만 objectMapper로 수동변환하였습니다.
- 데이터 포맷 변경이 필요할 경우, 컨버터만 수정하면 되므로 유지보수와 확장성이 좋습니다.